### PR TITLE
Updating various SAS macros

### DIFF
--- a/domino.sas
+++ b/domino.sas
@@ -48,12 +48,13 @@
 * global constants - USER CONFIGURABLE. Change these here if needed;
  
 * Location of Domino Datasets folders that are defined in this project;
-* Dependent on whether project is DFS or Git hosted;
 %global __localdata_path;
 * Location of mounted shared Domino Datasets;
 %global __sharedata_path;
 * Location of imported code repositories;
 %global __imported_git_path;
+* Location of NetApp Volumes;
+%global __netapp_volume_path;
 
 * globals read in from env vars; 
 %global __WORKING_DIR  ; * path to root of working directory ;
@@ -61,8 +62,8 @@
 %global __DCUTDTC      ; * cutoff date in ISO8901 format ;
  
 * globals derived from env vars;
-%global __PROTOCOL;      * Protocol identifier e.g H2QMCLZZT; 
-%global __PROJECT_TYPE ; * project type: SDTM | ADAM | TFL ;
+%global __PROTOCOL;      * Protocol identifier e.g CDISC01; 
+%global __PROJECT_TYPE ; * project type: SDTM | RE ;
  
 * other globals exported by setup;
 %global __prog_path;     * full path to the program being run;
@@ -92,6 +93,7 @@
 * ==================================================================;
 %let __localdata_path = /mnt/data;
 %let __sharedata_path = /mnt/imported/data;
+%let __netapp_volume_path = /mnt/netapp-volumes;
 %let __imported_git_path = /mnt/imported/code;
 %let __results_path = /mnt/artifacts;
 
@@ -112,7 +114,7 @@ libname ADAMQC "&__localdata_path./ADAMQC";
 libname TFL "&__localdata_path./TFL";
 libname TFLQC "&__localdata_path./TFLQC";
 * Metadata;
-libname METADATA "&__localdata_path./METADATA";
+libname METADATA "&__netapp_volume_path./METADATA";
  
 * ==================================================================;
 * Set SASAUTOS to search for shared macros ;

--- a/domino.sas
+++ b/domino.sas
@@ -113,7 +113,10 @@ libname ADAM "&__localdata_path./ADAM";
 libname ADAMQC "&__localdata_path./ADAMQC";
 * Metadata;
 libname METADATA "&__netapp_volume_path./METADATA";
- 
+* local read/write for TFL datasets ;
+libname TFL "&__results_path./TFL";
+libname TFLQC "&__results_path./TFL_QC";
+
 * ==================================================================;
 * Set SASAUTOS to search for shared macros ;
 * ==================================================================;

--- a/domino.sas
+++ b/domino.sas
@@ -93,7 +93,7 @@
 %let __localdata_path = /mnt/data;
 %let __sharedata_path = /mnt/imported/data;
 %let __imported_git_path = /mnt/imported/code;
-%let __results_path = /mnt/artifacts/sas_logs;
+%let __results_path = /mnt/artifacts;
 
 * ==================================================================;
 * define library locations for Reporting Effort (RE) project type;
@@ -178,7 +178,7 @@ options
 * ==================================================================;
 %if &__runmode eq %str(BATCH) %then %do;
   * Redirect SAS LOG files when in batch mode;
-  PROC PRINTTO LOG="&__results_path./&__prog_name..log" NEW;
+  PROC PRINTTO LOG="&__results_path./sas_logs/&__prog_name..log" NEW;
 %end;
  
 %mend __setup;

--- a/domino.sas
+++ b/domino.sas
@@ -96,40 +96,23 @@
 %let __results_path = /mnt/artifacts/TFL;
 
 * ==================================================================;
-* define library locations - these are dependent on the project type;
+* define library locations for Reporting Effort (RE) project type;
 * ==================================================================;
- 
-* SDTM ;
-* ------------------------------------------------------------------;
-%if %sysfunc(find(%upcase(&__PROJECT_TYPE.),SDTM)) ge 1 %then %do;
-  * Local read/write access to SDTM and QC folders ;
-  libname SDTMUNBD   "&__localdata_path./SDTMUNBLIND";
-  libname SDTMBLND "&__localdata_path./SDTMBLIND";
-  * Imported SDTM projects; 
-  libname RAW "&__sharedata_path./RAW" access=readonly;
-  libname UNBLIND "&__sharedata_path./UNBLIND" access=readonly;
-  libname BLIND "&__sharedata_path./BLIND" access=readonly;
-  * Metadata;
-  libname METADATA "&__localdata_path./METADATA";
-%end;
-
 * Reporting Effort (RE) project ;
 * ------------------------------------------------------------------;
-%if %sysfunc(find(%upcase(&__PROJECT_TYPE.),RE)) ge 1 %then %do;
-  * imported read-only SDTM data, using the data cutoff date.. ;
-  * .. and sdtm variable to identify the correct snapshot to use ;
-  %let __SDTM_DATASET = %sysget(SDTM_DATASET);
-  %if &__SDTM_DATASET. eq %str() %then %put %str(ER)ROR: Environment Variable SDTM_DATASET not set;
-  libname SDTM "/mnt/imported/data/snapshots/&__SDTM_DATASET./&__DCUTDTC." access=readonly;
-  * local read/write acces to ADaM and QC folders;
-  libname ADAM   "&__localdata_path./ADAM";
-  libname ADAMQC "&__localdata_path./ADAMQC";
-  * local read/write for TFL datasets ;
-  libname TFL   "&__localdata_path./TFL";
-  libname TFLQC "&__localdata_path./TFLQC";
-  * Metadata;
-  libname METADATA "&__localdata_path./METADATA";
-%end;
+* imported read-only SDTM data, using the data cutoff date.. ;
+* .. and sdtm variable to identify the correct snapshot to use ;
+%let __SDTM_DATASET = %sysget(SDTM_DATASET);
+%if &__SDTM_DATASET. eq %str() %then %put %str(ER)ROR: Environment Variable SDTM_DATASET not set;
+libname SDTM "/mnt/imported/data/snapshots/&__SDTM_DATASET./&__DCUTDTC." access=readonly;
+* local read/write acces to ADaM and QC folders;
+libname ADAM "&__localdata_path./ADAM";
+libname ADAMQC "&__localdata_path./ADAMQC";
+* local read/write for TFL datasets ;
+libname TFL "&__localdata_path./TFL";
+libname TFLQC "&__localdata_path./TFLQC";
+* Metadata;
+libname METADATA "&__localdata_path./METADATA";
  
 * ==================================================================;
 * Set SASAUTOS to search for shared macros ;

--- a/domino.sas
+++ b/domino.sas
@@ -112,7 +112,7 @@ libname SDTM "/mnt/imported/data/snapshots/&__SDTM_DATASET./&__DCUTDTC." access=
 libname ADAM "&__localdata_path./ADAM";
 libname ADAMQC "&__localdata_path./ADAMQC";
 * Metadata;
-libname METADATA "&__netapp_volume_path./METADATA";
+libname METADATA "&__netapp_volume_path./CDISC01_METADATA";
 * local read/write for TFL datasets ;
 libname TFL "&__results_path./TFL";
 libname TFLQC "&__results_path./TFL_QC";

--- a/domino.sas
+++ b/domino.sas
@@ -41,17 +41,6 @@
 *
 * Assumptions: 
 * - Must be run on the Domino platform (assumes Domino environment vars)
-* ____________________________________________________________________________
-* PROGRAM HISTORY                                                         
-*  2022-06-06  | Stuart.Malcolm  | Program created
-*  2022-09-28  | Stuart.Malcolm  | Ported code to TFL_Standard_Repo 
-*  2022-10-03  | Stuart.Malcolm  | Moved into study /share directory
-*  2022-10-20  | Stuart.Malcolm  | support ADAM/TFL combined projects
-*  2023-05-09  | Tom.Ratford     | Support new project structure
-*  2023-05-09  | Tom.Ratford     | Output log in batch
-*  2023-05-18  | Megan.Harries   | Include metadata libname for RE Interim
-* ----------------------------------------------------------------------------
-*  YYYYMMDD  |  username        | ..description of change..         
 *****************************************************************************/
  
 %macro __setup();
@@ -93,17 +82,10 @@
 %if &__DCUTDTC. eq %str() %then %put %str(ER)ROR: Envoronment Variable DCUTDTC not set;
  
 * ==================================================================;
-* extract the protocol and project type from the project name;
+* Hardcode protocol and project type;
 * ==================================================================;
-%if %sysfunc(find(&__PROJECT_NAME.,_)) ge 1 %then %do;
-  %* found an underscrore, so assume project name is <PROTOCOL>_<TYPE> ;
-  %let __PROTOCOL     = %scan(&__PROJECT_NAME.,1,'_');
-  %* project type is everything after the protocol in the project name ;
-  %let __PROJECT_TYPE = %sysfunc(tranwrd(&__PROJECT_NAME.,&__PROTOCOL._, %str()));
-  %end;
-%else %do;
-  %put %str(ER)ROR: Project Name (DOMINO_PROJECT_NAME) ill-formed. Expecting <PROTOCOL>_<TYPE> ;
-%end;
+%let __PROTOCOL = CDISC01;
+%let __PROJECT_TYPE = RE;
  
 * ==================================================================;
 * work out if the project is git or domino based

--- a/domino.sas
+++ b/domino.sas
@@ -30,6 +30,7 @@
 * - DOMINO_PROJECT_NAME
 * - DOMINO_WORKING_DIR
 * - DCUTDTC
+* - SDTM_DATASET
 *
 * Outputs:                                                   
 * - global variables defined

--- a/domino.sas
+++ b/domino.sas
@@ -93,7 +93,7 @@
 %let __localdata_path = /mnt/data;
 %let __sharedata_path = /mnt/imported/data;
 %let __imported_git_path = /mnt/imported/code;
-%let __results_path = /mnt/artifacts/TFL;
+%let __results_path = /mnt/artifacts/sas_logs;
 
 * ==================================================================;
 * define library locations for Reporting Effort (RE) project type;

--- a/domino.sas
+++ b/domino.sas
@@ -73,7 +73,7 @@
 %global __runmode;       * INTERACTIVE or BATCH (or UNKNOWN);
  
 * ==================================================================;
-* grab the environment varaibles that we need to create pathnames;
+* grab the default Domino environment variables that we need to create pathnames;
 * ==================================================================;
 %let __WORKING_DIR  = %sysget(DOMINO_WORKING_DIR);
 %let __PROJECT_NAME = %sysget(DOMINO_PROJECT_NAME);

--- a/domino.sas
+++ b/domino.sas
@@ -88,26 +88,12 @@
 %let __PROJECT_TYPE = RE;
  
 * ==================================================================;
-* work out if the project is git or domino based
+* Set paths for git-based project;
 * ==================================================================;
-* !!ALERT!! DOMINO_IS_GIT_BASED is an undocumented environment variable;
-%let __is_git_project = %sysget(DOMINO_IS_GIT_BASED);
-%if %upcase(&__is_git_project) eq %str(TRUE) %then %do;
-  * local & imported dataset location;
-  %let __localdata_path = /mnt/data;
-  %let __sharedata_path = /mnt/imported/data;
-  * imported code location;
-  %let __imported_git_path = /mnt/imported/code;
-  * set  directory  where outputs (TFL) are written to;
-  %let __results_path=/mnt/artifacts/results;
-%end; %else %do;
-  %let __localdata_path = /domino/datasets/local;
-  %let __sharedata_path = /domino/datasets;
-  * Imported code repository location;
-  %let __imported_git_path = /repos;
-  * set  directory  where outputs (TFL) are written to;
-  %let __results_path=&__WORKING_DIR./results;
-%end;
+%let __localdata_path = /mnt/data;
+%let __sharedata_path = /mnt/imported/data;
+%let __imported_git_path = /mnt/imported/code;
+%let __results_path = /mnt/artifacts/TFL;
 
 * ==================================================================;
 * define library locations - these are dependent on the project type;

--- a/domino.sas
+++ b/domino.sas
@@ -112,7 +112,7 @@ libname SDTM "/mnt/imported/data/snapshots/&__SDTM_DATASET./&__DCUTDTC." access=
 libname ADAM "&__localdata_path./ADAM";
 libname ADAMQC "&__localdata_path./ADAMQC";
 * Metadata;
-libname METADATA "&__netapp_volume_path./CDISC01_METADATA";
+libname METADATA "&__localdata_path./METADATA";
 * local read/write for TFL datasets ;
 libname TFL "&__results_path./TFL";
 libname TFLQC "&__results_path./TFL_QC";

--- a/domino.sas
+++ b/domino.sas
@@ -70,7 +70,7 @@
 %global __prog_path;     * full path to the program being run;
 %global __prog_name;     * filename (without extension) of program;
 %global __prog_ext;      * extension of program (usuall sas);
-%global __results_path;  * path to output file (e.g. for TFL write);
+%global __results_path;  * path to output file (e.g. for ADAM write);
 %global __full_path;     * full path and filename of program;
 %global __runmode;       * INTERACTIVE or BATCH (or UNKNOWN);
  
@@ -111,9 +111,6 @@ libname SDTM "/mnt/imported/data/snapshots/&__SDTM_DATASET./&__DCUTDTC." access=
 * local read/write acces to ADaM and QC folders;
 libname ADAM "&__localdata_path./ADAM";
 libname ADAMQC "&__localdata_path./ADAMQC";
-* local read/write for TFL datasets ;
-libname TFL "&__localdata_path./TFL";
-libname TFLQC "&__localdata_path./TFLQC";
 * Metadata;
 libname METADATA "&__netapp_volume_path./METADATA";
  

--- a/flows/flow_1_dev.py
+++ b/flows/flow_1_dev.py
@@ -10,6 +10,10 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
+# Default for caching, set to True or False
+cache = False
+
+
 # Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
 # pyflyte run --remote ./flows/flow_1_dev.py ADaM_only --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND 
 
@@ -31,7 +35,9 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adsl_dataset", type=DataArtifact.File(name="adsl", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
  
     adae_task = run_domino_job_task(
@@ -42,7 +48,9 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adae_dataset", type=DataArtifact.File(name="adae", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     
     adcm_task = run_domino_job_task(
@@ -53,7 +61,9 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adcm_dataset", type=DataArtifact.File(name="adcm", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     adlb_task = run_domino_job_task(
@@ -64,7 +74,9 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adlb_dataset", type=DataArtifact.File(name="adlb", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     admh_task = run_domino_job_task(
@@ -75,7 +87,9 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="admh_dataset", type=DataArtifact.File(name="admh", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     advs_task = run_domino_job_task(
@@ -86,7 +100,9 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="advs_dataset", type=DataArtifact.File(name="advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     return

--- a/flows/flow_1_dev.py
+++ b/flows/flow_1_dev.py
@@ -10,22 +10,20 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
-
 # Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
-# pyflyte run --remote ./flows/flow_3.py ADaM_only_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND
+# pyflyte run --remote ./flows/flow_1_dev.py ADaM_only --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND 
 
 # If you want to give the run a name, then use this command and replace the MY_CUSTOM_NAME argument
-# pyflyte run --remote --name MY_CUSTOM_NAME ./flows/flow_3.py ADaM_only_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND
+# pyflyte run --remote --name ENTER_RUN_NAME ./flows/flow_1_dev.py ADaM_only --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND 
 
 
-# Define two Flow Artifacts called ADaM Dataset and QC ADaM Dataset to tag and group ADaM outputs respectively
+# Define one Flow Artifact called ADaM Dataset to tag and group all of the ADAM task outputs as
 DataArtifact = Artifact("ADaM Datasets", DATA)
-QCDataArtifact = Artifact("QC ADaM Datasets", DATA)
+
 
 @workflow
-def ADaM_only_QC(sdtm_dataset_snapshot: str):
+def ADaM_only(sdtm_dataset_snapshot: str):
 
-    #PROD 
     adsl_task = run_domino_job_task(
         flyte_task_name="Create ADSL Dataset",
         command="prod/adam/ADSL.sas",
@@ -34,9 +32,8 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
-    ) 
-
-    #PROD 
+    )
+ 
     adae_task = run_domino_job_task(
         flyte_task_name="Create ADAE Dataset",
         command="prod/adam/ADAE.sas",
@@ -47,7 +44,7 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-    #PROD 
+    
     adcm_task = run_domino_job_task(
         flyte_task_name="Create ADCM Dataset",
         command="prod/adam/ADCM.sas",
@@ -58,7 +55,7 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-    #PROD 
+
     adlb_task = run_domino_job_task(
         flyte_task_name="Create ADLB Dataset",
         command="prod/adam/ADLB.sas",
@@ -67,9 +64,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adlb_dataset", type=DataArtifact.File(name="adlb", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True,
+        use_project_defaults_for_omitted=True
     )
-    #PROD 
+
     admh_task = run_domino_job_task(
         flyte_task_name="Create ADMH Dataset",
         command="prod/adam/ADMH.sas",
@@ -80,7 +77,7 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-    #PROD 
+
     advs_task = run_domino_job_task(
         flyte_task_name="Create ADVS Dataset",
         command="prod/adam/ADVS.sas",
@@ -91,71 +88,5 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-    #QC 
-    qc_adsl_task = run_domino_job_task(
-        flyte_task_name="Create QC ADSL Dataset",
-        command="qc/adam/qc_ADSL.sas",
-        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
-        output_specs=[Output(name="qc_adsl_dataset", type=QCDataArtifact.File(name="qc_adsl", type="sas7bdat"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True,
-    ) 
- 
-    #QC 
-    qc_adae_task = run_domino_job_task(
-        flyte_task_name="Create QC ADAE Dataset",
-        command="qc/adam/qc_ADAE.sas",
-        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
-                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
-        output_specs=[Output(name="qc_adae_dataset", type=QCDataArtifact.File(name="qc_adae", type="sas7bdat"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
-    #QC 
-    qc_adcm_task = run_domino_job_task(
-        flyte_task_name="Create QC ADCM Dataset",
-        command="qc/adam/qc_ADCM.sas",
-        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
-                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
-        output_specs=[Output(name="qc_adcm_dataset", type=QCDataArtifact.File(name="qc_adcm", type="sas7bdat"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
-    #QC 
-    qc_adlb_task = run_domino_job_task(
-        flyte_task_name="Create QC ADLB Dataset",
-        command="qc/adam/qc_ADLB.sas",
-        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
-                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
-        output_specs=[Output(name="qc_adlb_dataset", type=QCDataArtifact.File(name="qc_adlb", type="sas7bdat"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
-    #QC 
-    qc_admh_task = run_domino_job_task(
-        flyte_task_name="Create QC ADMH Dataset",
-        command="qc/adam/qc_ADMH.sas",
-        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
-                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
-        output_specs=[Output(name="qc_admh_dataset", type=QCDataArtifact.File(name="qc_admh", type="sas7bdat"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
-    #QC 
-    qc_advs_task = run_domino_job_task(
-        flyte_task_name="Create QC ADVS Dataset",
-        command="qc/adam/qc_ADVS.sas",
-        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
-                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
-        output_specs=[Output(name="qc_advs_dataset", type=QCDataArtifact.File(name="qc_advs", type="sas7bdat"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
 
-    return 
+    return

--- a/flows/flow_2_dev.py
+++ b/flows/flow_2_dev.py
@@ -10,6 +10,8 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
+# Default for caching, set to True or False
+cache = False
 
 # Enter the command below to run this Flow. There are two Flow input parameters. One for the SDTM Dataset snapshot and one for the METADATA dataset snapshot.
 # pyflyte run --remote ./flows/flow_2_dev.py ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
@@ -32,7 +34,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adsl_dataset", type=DataArtifact.File(name="adsl", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     ) 
 
     adae_task = run_domino_job_task(
@@ -43,7 +47,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adae_dataset", type=DataArtifact.File(name="adae", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     
     adcm_task = run_domino_job_task(
@@ -54,7 +60,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adcm_dataset", type=DataArtifact.File(name="adcm", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     adlb_task = run_domino_job_task(
@@ -65,7 +73,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adlb_dataset", type=DataArtifact.File(name="adlb", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     admh_task = run_domino_job_task(
@@ -76,7 +86,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="admh_dataset", type=DataArtifact.File(name="admh", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     advs_task = run_domino_job_task(
@@ -87,7 +99,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="advs_dataset", type=DataArtifact.File(name="advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     t_pop_task = run_domino_job_task(
@@ -98,7 +112,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_pop", type=ReportArtifact.File(name="t_pop", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     t_ae_rel_task = run_domino_job_task(
@@ -110,7 +126,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_ae_rel", type=ReportArtifact.File(name="t_ae_rel", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     t_vscat_task = run_domino_job_task(
@@ -121,7 +139,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_vscat", type=ReportArtifact.File(name="t_vscat", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     return

--- a/flows/flow_2_dev.py
+++ b/flows/flow_2_dev.py
@@ -1,6 +1,6 @@
 from flytekit import workflow
 from flytekit.types.file import FlyteFile
-from typing import TypeVar, NamedTuple, Tuple
+from typing import TypeVar, NamedTuple
 from flytekitplugins.domino.helpers import Input, Output, run_domino_job_task
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef, EnvironmentRevisionSpecification, EnvironmentRevisionType, DatasetSnapshot
 from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
@@ -10,19 +10,20 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
-# Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
-# pyflyte run --remote ./flows/flow_1.py ADaM_only --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND 
+
+# Enter the command below to run this Flow. There are two Flow input parameters. One for the SDTM Dataset snapshot and one for the METADATA dataset snapshot.
+# pyflyte run --remote ./flows/flow_2_dev.py ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
 
 # If you want to give the run a name, then use this command and replace the MY_CUSTOM_NAME argument
-# pyflyte run --remote --name MY_CUSTOM_NAME ./flows/flow_1.py ADaM_only --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND 
+# pyflyte run --remote --name ENTER_RUN_NAME ./flows/flow_2_dev.py ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
 
 
-# Define one Flow Artifact called ADaM Dataset to tag and group all of the ADAM task outputs as
+# Define two Flow Artifacts called ADaM Dataset and TFL Reports to tag and group ADaM and TFL outputs respectively
 DataArtifact = Artifact("ADaM Datasets", DATA)
-
+ReportArtifact = Artifact("TFL Reports", REPORT)
 
 @workflow
-def ADaM_only(sdtm_dataset_snapshot: str):
+def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str): 
 
     adsl_task = run_domino_job_task(
         flyte_task_name="Create ADSL Dataset",
@@ -32,8 +33,8 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
-    )
- 
+    ) 
+
     adae_task = run_domino_job_task(
         flyte_task_name="Create ADAE Dataset",
         command="prod/adam/ADAE.sas",
@@ -84,6 +85,40 @@ def ADaM_only(sdtm_dataset_snapshot: str):
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
                 Input(name="adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl_dataset"])],
         output_specs=[Output(name="advs_dataset", type=DataArtifact.File(name="advs", type="sas7bdat"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+
+    t_pop_task = run_domino_job_task(
+        flyte_task_name="Create T_POP Report",
+        command="prod/tfl/t_pop.sas",
+        inputs=[Input(name="adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl_dataset"]),
+                Input(name="metadata_snapshot", type=str, value=metadata_snapshot)],
+        output_specs=[Output(name="t_pop", type=ReportArtifact.File(name="t_pop", type="pdf"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+
+    t_ae_rel_task = run_domino_job_task(
+        flyte_task_name="Create T_AE_REL Report",
+        command="prod/tfl/t_ae_rel.sas",
+        inputs=[Input(name="adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl_dataset"]),
+                Input(name="adae_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adae_task["adae_dataset"]),
+                Input(name="metadata_snapshot", type=str, value=metadata_snapshot)],
+        output_specs=[Output(name="t_ae_rel", type=ReportArtifact.File(name="t_ae_rel", type="pdf"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+
+    t_vscat_task = run_domino_job_task(
+        flyte_task_name="Create T_VSCAT Report",
+        command="prod/tfl/t_vscat.sas",
+        inputs=[Input(name="advs_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=advs_task["advs_dataset"]),
+                Input(name="metadata_snapshot", type=str, value=metadata_snapshot)],
+        output_specs=[Output(name="t_vscat", type=ReportArtifact.File(name="t_vscat", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True

--- a/flows/flow_3_dev.py
+++ b/flows/flow_3_dev.py
@@ -1,6 +1,6 @@
 from flytekit import workflow
 from flytekit.types.file import FlyteFile
-from typing import TypeVar, NamedTuple
+from typing import TypeVar, NamedTuple, Tuple
 from flytekitplugins.domino.helpers import Input, Output, run_domino_job_task
 from flytekitplugins.domino.task import DominoJobConfig, DominoJobTask, GitRef, EnvironmentRevisionSpecification, EnvironmentRevisionType, DatasetSnapshot
 from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
@@ -11,20 +11,21 @@ environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
 
-# Enter the command below to run this Flow. There are two Flow input parameters. One for the SDTM Dataset snapshot and one for the METADATA dataset snapshot.
-# pyflyte run --remote ./flows/flow_2.py ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
+# Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
+# pyflyte run --remote ./flows/flow_3_dev.py ADaM_only_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND
 
 # If you want to give the run a name, then use this command and replace the MY_CUSTOM_NAME argument
-# pyflyte run --remote --name MY_CUSTOM_NAME ./flows/flow_2.py ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
+# pyflyte run --remote --name ENTER_RUN_NAME ./flows/flow_3_dev.py ADaM_only_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND
 
 
-# Define two Flow Artifacts called ADaM Dataset and TFL Reports to tag and group ADaM and TFL outputs respectively
+# Define two Flow Artifacts called ADaM Dataset and QC ADaM Dataset to tag and group ADaM outputs respectively
 DataArtifact = Artifact("ADaM Datasets", DATA)
-ReportArtifact = Artifact("TFL Reports", REPORT)
+QCDataArtifact = Artifact("QC ADaM Datasets", DATA)
 
 @workflow
-def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str): 
+def ADaM_only_QC(sdtm_dataset_snapshot: str):
 
+    #PROD 
     adsl_task = run_domino_job_task(
         flyte_task_name="Create ADSL Dataset",
         command="prod/adam/ADSL.sas",
@@ -35,6 +36,7 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         use_project_defaults_for_omitted=True
     ) 
 
+    #PROD 
     adae_task = run_domino_job_task(
         flyte_task_name="Create ADAE Dataset",
         command="prod/adam/ADAE.sas",
@@ -45,7 +47,7 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-    
+    #PROD 
     adcm_task = run_domino_job_task(
         flyte_task_name="Create ADCM Dataset",
         command="prod/adam/ADCM.sas",
@@ -56,7 +58,7 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-
+    #PROD 
     adlb_task = run_domino_job_task(
         flyte_task_name="Create ADLB Dataset",
         command="prod/adam/ADLB.sas",
@@ -65,9 +67,9 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adlb_dataset", type=DataArtifact.File(name="adlb", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
     )
-
+    #PROD 
     admh_task = run_domino_job_task(
         flyte_task_name="Create ADMH Dataset",
         command="prod/adam/ADMH.sas",
@@ -78,7 +80,7 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-
+    #PROD 
     advs_task = run_domino_job_task(
         flyte_task_name="Create ADVS Dataset",
         command="prod/adam/ADVS.sas",
@@ -89,39 +91,71 @@ def ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
-
-    t_pop_task = run_domino_job_task(
-        flyte_task_name="Create T_POP Report",
-        command="prod/tfl/t_pop.sas",
-        inputs=[Input(name="adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl_dataset"]),
-                Input(name="metadata_snapshot", type=str, value=metadata_snapshot)],
-        output_specs=[Output(name="t_pop", type=ReportArtifact.File(name="t_pop", type="pdf"))],
+    #QC 
+    qc_adsl_task = run_domino_job_task(
+        flyte_task_name="Create QC ADSL Dataset",
+        command="qc/adam/qc_ADSL.sas",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
+        output_specs=[Output(name="qc_adsl_dataset", type=QCDataArtifact.File(name="qc_adsl", type="sas7bdat"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True,
+    ) 
+ 
+    #QC 
+    qc_adae_task = run_domino_job_task(
+        flyte_task_name="Create QC ADAE Dataset",
+        command="qc/adam/qc_ADAE.sas",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
+                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
+        output_specs=[Output(name="qc_adae_dataset", type=QCDataArtifact.File(name="qc_adae", type="sas7bdat"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+    #QC 
+    qc_adcm_task = run_domino_job_task(
+        flyte_task_name="Create QC ADCM Dataset",
+        command="qc/adam/qc_ADCM.sas",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
+                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
+        output_specs=[Output(name="qc_adcm_dataset", type=QCDataArtifact.File(name="qc_adcm", type="sas7bdat"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+    #QC 
+    qc_adlb_task = run_domino_job_task(
+        flyte_task_name="Create QC ADLB Dataset",
+        command="qc/adam/qc_ADLB.sas",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
+                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
+        output_specs=[Output(name="qc_adlb_dataset", type=QCDataArtifact.File(name="qc_adlb", type="sas7bdat"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+    #QC 
+    qc_admh_task = run_domino_job_task(
+        flyte_task_name="Create QC ADMH Dataset",
+        command="qc/adam/qc_ADMH.sas",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
+                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
+        output_specs=[Output(name="qc_admh_dataset", type=QCDataArtifact.File(name="qc_admh", type="sas7bdat"))],
+        hardware_tier_name=hardware_tier_name,
+        environment_name=environment_name,
+        use_project_defaults_for_omitted=True
+    )
+    #QC 
+    qc_advs_task = run_domino_job_task(
+        flyte_task_name="Create QC ADVS Dataset",
+        command="qc/adam/qc_ADVS.sas",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot),
+                Input(name="qc_adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=qc_adsl_task["qc_adsl_dataset"])],
+        output_specs=[Output(name="qc_advs_dataset", type=QCDataArtifact.File(name="qc_advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True
     )
 
-    t_ae_rel_task = run_domino_job_task(
-        flyte_task_name="Create T_AE_REL Report",
-        command="prod/tfl/t_ae_rel.sas",
-        inputs=[Input(name="adsl_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl_dataset"]),
-                Input(name="adae_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=adae_task["adae_dataset"]),
-                Input(name="metadata_snapshot", type=str, value=metadata_snapshot)],
-        output_specs=[Output(name="t_ae_rel", type=ReportArtifact.File(name="t_ae_rel", type="pdf"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
-
-    t_vscat_task = run_domino_job_task(
-        flyte_task_name="Create T_VSCAT Report",
-        command="prod/tfl/t_vscat.sas",
-        inputs=[Input(name="advs_dataset", type=FlyteFile[TypeVar("sas7bdat")], value=advs_task["advs_dataset"]),
-                Input(name="metadata_snapshot", type=str, value=metadata_snapshot)],
-        output_specs=[Output(name="t_vscat", type=ReportArtifact.File(name="t_vscat", type="pdf"))],
-        hardware_tier_name=hardware_tier_name,
-        environment_name=environment_name,
-        use_project_defaults_for_omitted=True
-    )
-
-    return
+    return 

--- a/flows/flow_3_dev.py
+++ b/flows/flow_3_dev.py
@@ -10,6 +10,8 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
+# Default for caching, set to True or False
+cache = False
 
 # Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
 # pyflyte run --remote ./flows/flow_3_dev.py ADaM_only_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND
@@ -33,7 +35,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adsl_dataset", type=DataArtifact.File(name="adsl", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     ) 
 
     #PROD 
@@ -45,7 +49,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adae_dataset", type=DataArtifact.File(name="adae", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #PROD 
     adcm_task = run_domino_job_task(
@@ -56,7 +62,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="adcm_dataset", type=DataArtifact.File(name="adcm", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #PROD 
     adlb_task = run_domino_job_task(
@@ -68,6 +76,8 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0",
     )
     #PROD 
     admh_task = run_domino_job_task(
@@ -78,7 +88,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="admh_dataset", type=DataArtifact.File(name="admh", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #PROD 
     advs_task = run_domino_job_task(
@@ -89,7 +101,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="advs_dataset", type=DataArtifact.File(name="advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_adsl_task = run_domino_job_task(
@@ -100,6 +114,8 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0",
     ) 
  
     #QC 
@@ -111,7 +127,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="qc_adae_dataset", type=QCDataArtifact.File(name="qc_adae", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_adcm_task = run_domino_job_task(
@@ -122,7 +140,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="qc_adcm_dataset", type=QCDataArtifact.File(name="qc_adcm", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_adlb_task = run_domino_job_task(
@@ -133,7 +153,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="qc_adlb_dataset", type=QCDataArtifact.File(name="qc_adlb", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_admh_task = run_domino_job_task(
@@ -144,7 +166,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="qc_admh_dataset", type=QCDataArtifact.File(name="qc_admh", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_advs_task = run_domino_job_task(
@@ -155,7 +179,9 @@ def ADaM_only_QC(sdtm_dataset_snapshot: str):
         output_specs=[Output(name="qc_advs_dataset", type=QCDataArtifact.File(name="qc_advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     return 

--- a/flows/flow_4_dev.py
+++ b/flows/flow_4_dev.py
@@ -10,6 +10,8 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
+# Default for caching, set to True or False
+cache = False
 
 # Enter the command below to run this Flow. There are two Flow input parameters. One for the SDTM Dataset snapshot and one for the METADATA dataset snapshot.
 # pyflyte run --remote ./flows/flow_4_dev.py ADaM_TFL_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
@@ -37,7 +39,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adsl_dataset", type=DataArtifact.File(name="adsl", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     ) 
 
     #PROD 
@@ -49,7 +53,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adae_dataset", type=DataArtifact.File(name="adae", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #PROD 
     adcm_task = run_domino_job_task(
@@ -60,7 +66,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adcm_dataset", type=DataArtifact.File(name="adcm", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #PROD 
     adlb_task = run_domino_job_task(
@@ -72,6 +80,8 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0",
     )
     #PROD 
     admh_task = run_domino_job_task(
@@ -82,7 +92,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="admh_dataset", type=DataArtifact.File(name="admh", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #PROD 
     advs_task = run_domino_job_task(
@@ -93,7 +105,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="advs_dataset", type=DataArtifact.File(name="advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_adsl_task = run_domino_job_task(
@@ -104,6 +118,8 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
         use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0",
     ) 
  
     #QC 
@@ -115,7 +131,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_adae_dataset", type=QCDataArtifact.File(name="qc_adae", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_adcm_task = run_domino_job_task(
@@ -126,7 +144,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_adcm_dataset", type=QCDataArtifact.File(name="qc_adcm", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_adlb_task = run_domino_job_task(
@@ -137,7 +157,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_adlb_dataset", type=QCDataArtifact.File(name="qc_adlb", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_admh_task = run_domino_job_task(
@@ -148,7 +170,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_admh_dataset", type=QCDataArtifact.File(name="qc_admh", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     #QC 
     qc_advs_task = run_domino_job_task(
@@ -159,7 +183,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_advs_dataset", type=QCDataArtifact.File(name="qc_advs", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     #PROD
@@ -171,7 +197,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_pop", type=ReportArtifact.File(name="t_pop", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     #PROD
@@ -184,7 +212,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_ae_rel", type=ReportArtifact.File(name="t_ae_rel", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     #PROD
@@ -196,7 +226,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_vscat", type=ReportArtifact.File(name="t_vscat", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     #QC
@@ -208,7 +240,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_t_pop", type=QCReportArtifact.File(name="qc_t_pop", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     #QC
@@ -221,7 +255,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_t_ae_rel", type=QCReportArtifact.File(name="qc_t_ae_rel", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
     
     #QC
@@ -233,7 +269,9 @@ def ADaM_TFL_QC(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="qc_t_vscat", type=QCReportArtifact.File(name="qc_t_vscat", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     return 

--- a/flows/flow_4_dev.py
+++ b/flows/flow_4_dev.py
@@ -12,10 +12,10 @@ hardware_tier_name="Small"
 
 
 # Enter the command below to run this Flow. There are two Flow input parameters. One for the SDTM Dataset snapshot and one for the METADATA dataset snapshot.
-# pyflyte run --remote ./flows/flow_4.py ADaM_TFL_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
+# pyflyte run --remote ./flows/flow_4_dev.py ADaM_TFL_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
 
 # If you want to give the run a name, then use this command and replace the MY_CUSTOM_NAME argument
-# pyflyte run --remote --name MY_CUSTOM_NAME ./flows/flow_4.py ADaM_TFL_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA
+# pyflyte run --remote --name ENTER_RUN_NAME ./flows/flow_4_dev.py ADaM_TFL_QC --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA
 
 
 

--- a/flows/flow_5_dev.py
+++ b/flows/flow_5_dev.py
@@ -12,10 +12,10 @@ hardware_tier_name="Small"
 
 
 # Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
-# pyflyte run --remote ./flows/flow_5.py SDTM_ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
+# pyflyte run --remote ./flows/flow_5_dev.py SDTM_ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
 
 # If you want to give the run a name, then use this command and replace the MY_CUSTOM_NAME argument
-# pyflyte run --remote --name MY_CUSTOM_NAME ./flows/flow_5.py SDTM_ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
+# pyflyte run --remote --name ENTER_RUN_NAME ./flows/flow_5_dev.py SDTM_ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
 
 
 # Define two Flow Artifacts called ADaM Dataset and TFL Reports to tag and group ADaM and TFL outputs respectively

--- a/flows/flow_5_dev.py
+++ b/flows/flow_5_dev.py
@@ -10,6 +10,8 @@ from flytekitplugins.domino.artifact import Artifact, DATA, MODEL, REPORT
 environment_name="SAS Analytics Pro"
 hardware_tier_name="Small"
 
+# Default for caching, set to True or False
+cache = False
 
 # Enter the command below to run this Flow. There is a single Flow input parameter for the SDTM Dataset snapshot
 # pyflyte run --remote ./flows/flow_5_dev.py SDTM_ADaM_TFL --sdtm_dataset_snapshot /mnt/imported/data/SDTMBLIND --metadata_snapshot /mnt/data/METADATA 
@@ -33,7 +35,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="ae", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Move cm from Dataset to Flows node
@@ -44,7 +48,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="cm", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Move dm from Dataset to Flows node
@@ -55,7 +61,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="dm", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Move ex from Dataset to Flows node
@@ -66,7 +74,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="ex", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Move lb from Dataset to Flows node
@@ -77,7 +87,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="lb", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Move mh from Dataset to Flows node
@@ -88,7 +100,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="mh", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Move vs from Dataset to Flows node
@@ -99,7 +113,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="vs", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
         environment_name="GxP R & Python",
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create ADSL dataset from the output of dm_task
@@ -110,7 +126,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adsl_dataset", type=DataArtifact.File(name="adsl.sas7bdat", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create ADAE dataset from the output of ae_task, ex_task and adsl_task
@@ -123,7 +141,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adae_dataset", type=DataArtifact.File(name="adae.sas7bdat", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create ADCM dataset from the output of cm_task and adsl_task
@@ -135,7 +155,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adcm_dataset", type=DataArtifact.File(name="adcm.sas7bdat", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create ADLB dataset from the output of lb_task and adsl_task
@@ -147,7 +169,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="adlb_dataset", type=DataArtifact.File(name="adlb.sas7bdat", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create ADMH dataset from the output of lb_task and adsl_task
@@ -159,7 +183,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="admh_dataset", type=DataArtifact.File(name="admh.sas7bdat", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create ADVS dataset from the output of vs_task and adsl_task
@@ -171,7 +197,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="advs_dataset", type=DataArtifact.File(name="advs.sas7bdat", type="sas7bdat"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create T_POP report from the output of adsl_task and the metadata dataset launch parameter
@@ -183,7 +211,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_pop", type=ReportArtifact.File(name="t_pop", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create T_AE_REL report from the output of adsl_task, adae_task and the metadata dataset launch parameter
@@ -196,7 +226,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_ae_rel", type=ReportArtifact.File(name="t_ae_rel", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     # Create T_VSCAT report from the output of adsl_task, adae_task and the metadata dataset launch parameter
@@ -208,7 +240,9 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
         output_specs=[Output(name="t_vscat", type=ReportArtifact.File(name="t_vscat", type="pdf"))],
         hardware_tier_name=hardware_tier_name,
         environment_name=environment_name,
-        use_project_defaults_for_omitted=True
+        use_project_defaults_for_omitted=True,
+        cache=cache,
+        cache_version="1.0"
     )
 
     return

--- a/flows/flow_5_dev.py
+++ b/flows/flow_5_dev.py
@@ -28,7 +28,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move ae from Dataset to Flows node
     ae_task = run_domino_job_task(
         flyte_task_name="ae SDTM",
-        command="utils/SDTM_transfer/ae.py",
+        command="code/utils/SDTM_transfer/ae.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="ae", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
@@ -39,7 +39,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move cm from Dataset to Flows node
     cm_task = run_domino_job_task(
         flyte_task_name="cm SDTM",
-        command="utils/SDTM_transfer/cm.py",
+        command="code/utils/SDTM_transfer/cm.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="cm", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
@@ -50,7 +50,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move dm from Dataset to Flows node
     dm_task = run_domino_job_task(
         flyte_task_name="dm SDTM",
-        command="utils/SDTM_transfer/dm.py",
+        command="code/utils/SDTM_transfer/dm.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="dm", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
@@ -61,7 +61,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move ex from Dataset to Flows node
     ex_task = run_domino_job_task(
         flyte_task_name="ex SDTM",
-        command="utils/SDTM_transfer/ex.py",
+        command="code/utils/SDTM_transfer/ex.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="ex", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
@@ -72,7 +72,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move lb from Dataset to Flows node
     lb_task = run_domino_job_task(
         flyte_task_name="lb SDTM",
-        command="utils/SDTM_transfer/lb.py",
+        command="code/utils/SDTM_transfer/lb.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="lb", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
@@ -83,7 +83,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move mh from Dataset to Flows node
     mh_task = run_domino_job_task(
         flyte_task_name="mh SDTM",
-        command="utils/SDTM_transfer/mh.py",
+        command="code/utils/SDTM_transfer/mh.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="mh", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,
@@ -94,7 +94,7 @@ def SDTM_ADaM_TFL(sdtm_dataset_snapshot: str, metadata_snapshot: str):
     # Move vs from Dataset to Flows node
     vs_task = run_domino_job_task(
         flyte_task_name="vs SDTM",
-        command="utils/SDTM_transfer/vs.py",
+        command="code/utils/SDTM_transfer/vs.py",
         inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
         output_specs=[Output(name="vs", type=FlyteFile[TypeVar('sas7bdat')])],
         hardware_tier_name=hardware_tier_name,

--- a/utils/import_metadata.sas
+++ b/utils/import_metadata.sas
@@ -32,7 +32,7 @@
 
 * Convert Display sheet of xlsx to sas7bdat;
 proc import out = tfl
-			datafile = "&__netapp_volume_path./METADATA/TFL_Metadata.xlsx"
+			datafile = "&__netapp_volume_path./CDISC01_METADATA/TFL_Metadata.xlsx"
 			dbms = xlsx replace;
 	sheet = "Display";
 	getnames = YES;

--- a/utils/import_metadata.sas
+++ b/utils/import_metadata.sas
@@ -32,7 +32,7 @@
 
 * Convert Display sheet of xlsx to sas7bdat;
 proc import out = tfl
-			datafile = "/mnt/netapp-volumes/MDR/TFL_Metadata.xlsx"
+			datafile = "&__netapp_volume_path./METADATA/TFL_Metadata.xlsx"
 			dbms = xlsx replace;
 	sheet = "Display";
 	getnames = YES;

--- a/utils/import_metadata.sas
+++ b/utils/import_metadata.sas
@@ -32,7 +32,7 @@
 
 * Convert Display sheet of xlsx to sas7bdat;
 proc import out = tfl
-			datafile = "&__netapp_volume_path./CDISC01_METADATA/TFL_Metadata.xlsx"
+			datafile = "&__netapp_volume_path./MDR/TFL_Metadata.xlsx"
 			dbms = xlsx replace;
 	sheet = "Display";
 	getnames = YES;

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -13,6 +13,7 @@ domino = Domino(f"{DOMINO_PROJECT_OWNER}/{DOMINO_PROJECT_NAME}")
 
 # Required Datasets & Descriptions
 REQUIRED = {
+    "METADATA": "Internal metadata",
     "COMPARE": "PROC COMPARE datasets for QC",
     "ADAM": "ADAM is created using SDTM data for production",
     "ADAMQC": "ADAMQC is created using SDTM data for qc"

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -13,7 +13,6 @@ domino = Domino(f"{DOMINO_PROJECT_OWNER}/{DOMINO_PROJECT_NAME}")
 
 # Required Datasets & Descriptions
 REQUIRED = {
-    "METADATA": "Internal metadata",
     "COMPARE": "PROC COMPARE datasets for QC",
     "ADAM": "ADAM is created using SDTM data for production",
     "ADAMQC": "ADAMQC is created using SDTM data for qc",
@@ -52,8 +51,7 @@ def submit_api_call(method, endpoint, data=None):
 # Mount imported datasets
 
 REQUIRED_MOUNTED = {
-    "SDTMBLIND",
-    "METADATA"
+    "SDTMBLIND"
 }
 
 # What datasets are currently mounted? And What are they called?

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -111,3 +111,6 @@ for missing_dataset in REQUIRED_MOUNTED.difference(CURRENT_MOUNTED):
 
 # Create TFL artifacts directory
 os.makedirs("/mnt/artifacts/TFL", exist_ok=True)
+
+# Create SAS logs artifacts directory
+os.makedirs("/mnt/artifacts/sas_logs", exist_ok=True)

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -108,4 +108,6 @@ for missing_dataset in REQUIRED_MOUNTED.difference(CURRENT_MOUNTED):
         print(f"ERROR: Could not find required dataset {missing_dataset} in {SDTM_PROJECT} datasets: {SDTM_DATASETS.keys()}")
     except Exception as e:
         print(e)
-        
+
+# Create TFL artifacts directory
+os.makedirs("/mnt/artifacts/TFL", exist_ok=True)

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -13,7 +13,7 @@ domino = Domino(f"{DOMINO_PROJECT_OWNER}/{DOMINO_PROJECT_NAME}")
 
 # Required Datasets & Descriptions
 REQUIRED = {
-    "METADATA": "Internal metadata",
+    "METADATA": "Internal metadata for the TFLs. Pulled from the MDR and converted to sas7bdat",
     "COMPARE": "PROC COMPARE datasets for QC",
     "ADAM": "ADAM is created using SDTM data for production",
     "ADAMQC": "ADAMQC is created using SDTM data for qc"

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -15,9 +15,7 @@ domino = Domino(f"{DOMINO_PROJECT_OWNER}/{DOMINO_PROJECT_NAME}")
 REQUIRED = {
     "COMPARE": "PROC COMPARE datasets for QC",
     "ADAM": "ADAM is created using SDTM data for production",
-    "ADAMQC": "ADAMQC is created using SDTM data for qc",
-    "TFL": "TFL is created using ADAM for production tfls",
-    "TFLQC": "TFLQC is created using ADAM for qc tfls"
+    "ADAMQC": "ADAMQC is created using SDTM data for qc"
 }
 
 # Existing Datasets

--- a/utils/init_datasets_re.py
+++ b/utils/init_datasets_re.py
@@ -110,5 +110,8 @@ for missing_dataset in REQUIRED_MOUNTED.difference(CURRENT_MOUNTED):
 # Create TFL artifacts directory
 os.makedirs("/mnt/artifacts/TFL", exist_ok=True)
 
+# Create QC TFL artifacts directory
+os.makedirs("/mnt/artifacts/TFL_QC", exist_ok=True)
+
 # Create SAS logs artifacts directory
 os.makedirs("/mnt/artifacts/sas_logs", exist_ok=True)


### PR DESCRIPTION
domino.sas changes
Removed need for specific project name format when users create their own project from the template
Hardcoded global macros 
PROTCOL = CDISC01
PROJECT_TYPE = RE
Removed IF statement that checks whether DFS or GBP
Set paths static for GBP 
Changed sas logs to be written to the /mnt/artifacts/sas_logs directory when running batch mode. 


Init_datasets.py changes 
(FYI this is a utility now for us to use when setting up the project you will create the project template from. Users will not need to run this utility as the project template will set all these things for then)
Added creation of /mnt/artifacts/TFL folder
Added creation of /mnt/artifacts/QC_TFL folder
Added creation of /mnt/artifacts/sas_logs folder
Removed creation of TFL and TFL QC datasets (TFLs are written to Artifacts, remove Datasets with the same name to avoid confusion). 


Import_metadata.sas
Updated the code so that it looks for the TFL_Metadata.xlsx in the MDR netapp volume and then writes out the sas7bdats to the METADATA dataset.
Ideally, we would just remove the need for the METADATA dataset, but we can’t do this until 6.2. This is because this metadata is required for TFL programs to run successfully, and since Flows cannot mount netapp volumes, we need the metadata to live in a Dataset in order for the TFL programs to run successfully in the Flows context.

