### PR TITLE
DOM-79203: CDISC1-shaped Flows Artifact Export scale harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dhparams.pem
 /utils/__pycache__
 /flows/__pycache__
 /Trash*
+generate_artifacts_scale_run.py
+/flows/__pycache__
+/scripts/__pycache__

--- a/flows/gen_scale_export_workflow.py
+++ b/flows/gen_scale_export_workflow.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Emit generate_artifacts_scale_run.py for a DOM-79203 scale profile.
+
+The generated workflow keeps the CDISC1 SDTM -> ADaM -> TFL fan-out from
+flows/dev/flow_5_all_SDTM.py, then adds extra artifact-producing tasks so the
+accumulated DATA artifacts match the Novartis file-count/size mix. A single
+programmatic dataset export covers both ADaM Datasets and Study Files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import pathlib
+import sys
+import textwrap
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from flows.scale_profiles import GIB, SDTM_DOMAINS, profile_batches, profile_totals
+
+SAS_ENVIRONMENT = "SAS Environment"
+WORKFLOW_NAME = "export_scale_study"
+OUTPUT_NAME = "generate_artifacts_scale_run.py"
+
+
+def _sdtm_tasks() -> str:
+    blocks = []
+    for domain in SDTM_DOMAINS:
+        blocks.append(
+            f"""
+    {domain}_task = run_domino_job_task(
+        flyte_task_name="{domain} SDTM",
+        command="utils/SDTM_transfer/{domain}.py",
+        inputs=[Input(name="sdtm_snapshot_task_input", type=str, value=sdtm_dataset_snapshot)],
+        output_specs=[Output(name="{domain}", type=FlyteFile[TypeVar("sas7bdat")])],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        cache=False,
+    )
+"""
+        )
+    return "".join(blocks)
+
+
+def _adam_tasks() -> str:
+    return """
+    adsl_task = run_domino_job_task(
+        flyte_task_name="Create ADSL Dataset",
+        command="prod/adam_scale/ADSL.sas",
+        inputs=[Input(name="dm", type=FlyteFile[TypeVar("sas7bdat")], value=dm_task["dm"])],
+        output_specs=[Output(name="adsl", type=DataArtifact.File(name="adsl.sas7bdat", type="sas7bdat"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    adae_task = run_domino_job_task(
+        flyte_task_name="Create ADAE Dataset",
+        command="prod/adam_scale/ADAE.sas",
+        inputs=[
+            Input(name="ae", type=FlyteFile[TypeVar("sas7bdat")], value=ae_task["ae"]),
+            Input(name="ex", type=FlyteFile[TypeVar("sas7bdat")], value=ex_task["ex"]),
+            Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"]),
+        ],
+        output_specs=[Output(name="adae", type=DataArtifact.File(name="adae.sas7bdat", type="sas7bdat"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    adcm_task = run_domino_job_task(
+        flyte_task_name="Create ADCM Dataset",
+        command="prod/adam_scale/ADCM.sas",
+        inputs=[
+            Input(name="cm", type=FlyteFile[TypeVar("sas7bdat")], value=cm_task["cm"]),
+            Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"]),
+        ],
+        output_specs=[Output(name="adcm", type=DataArtifact.File(name="adcm.sas7bdat", type="sas7bdat"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    adlb_task = run_domino_job_task(
+        flyte_task_name="Create ADLB Dataset",
+        command="prod/adam_scale/ADLB.sas",
+        inputs=[
+            Input(name="lb", type=FlyteFile[TypeVar("sas7bdat")], value=lb_task["lb"]),
+            Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"]),
+        ],
+        output_specs=[Output(name="adlb", type=DataArtifact.File(name="adlb.sas7bdat", type="sas7bdat"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    admh_task = run_domino_job_task(
+        flyte_task_name="Create ADMH Dataset",
+        command="prod/adam_scale/ADMH.sas",
+        inputs=[
+            Input(name="mh", type=FlyteFile[TypeVar("sas7bdat")], value=mh_task["mh"]),
+            Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"]),
+        ],
+        output_specs=[Output(name="admh", type=DataArtifact.File(name="admh.sas7bdat", type="sas7bdat"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    advs_task = run_domino_job_task(
+        flyte_task_name="Create ADVS Dataset",
+        command="prod/adam_scale/ADVS.sas",
+        inputs=[
+            Input(name="vs", type=FlyteFile[TypeVar("sas7bdat")], value=vs_task["vs"]),
+            Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"]),
+        ],
+        output_specs=[Output(name="advs", type=DataArtifact.File(name="advs.sas7bdat", type="sas7bdat"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+"""
+
+
+def _tfl_tasks() -> str:
+    return """
+    t_pop_task = run_domino_job_task(
+        flyte_task_name="Create T_POP Report",
+        command="prod/tfl_scale/t_pop.sas",
+        inputs=[Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"])],
+        output_specs=[Output(name="t_pop", type=ReportArtifact.File(name="t_pop.pdf", type="pdf"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    t_ae_rel_task = run_domino_job_task(
+        flyte_task_name="Create T_AE_REL Report",
+        command="prod/tfl_scale/t_ae_rel.sas",
+        inputs=[
+            Input(name="adsl", type=FlyteFile[TypeVar("sas7bdat")], value=adsl_task["adsl"]),
+            Input(name="adae", type=FlyteFile[TypeVar("sas7bdat")], value=adae_task["adae"]),
+        ],
+        output_specs=[Output(name="t_ae_rel", type=ReportArtifact.File(name="t_ae_rel.pdf", type="pdf"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+
+    t_vscat_task = run_domino_job_task(
+        flyte_task_name="Create T_VSCAT Report",
+        command="prod/tfl_scale/t_vscat.sas",
+        inputs=[Input(name="advs", type=FlyteFile[TypeVar("sas7bdat")], value=advs_task["advs"])],
+        output_specs=[Output(name="t_vscat", type=ReportArtifact.File(name="t_vscat.pdf", type="pdf"))],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        environment_name=SAS_ENVIRONMENT,
+        cache=False,
+    )
+"""
+
+
+def _emit_tasks(profile: str) -> str:
+    batches = profile_batches(profile)
+    blocks = []
+    for index, batch in enumerate(batches):
+        outputs = ",\n            ".join(
+            f'Output(name="{item.output_name}", type=StudyFilesArtifact.File(name="{item.artifact_filename}"))'
+            for item in batch
+        )
+        batch_bytes = sum(item.size_bytes for item in batch)
+        volume_gib = max(10, math.ceil(batch_bytes / GIB) + 4)
+        hardware = 'hardware_tier_id="small-k8s",' if batch_bytes >= GIB else ""
+        blocks.append(
+            f"""
+    study_files_batch_{index} = run_domino_job_task(
+        flyte_task_name="Emit study files batch {index}",
+        command="python /mnt/code/scripts/emit_scale_artifacts.py --profile {profile} --batch {index}",
+        output_specs=[
+            {outputs}
+        ],
+        use_project_defaults_for_omitted=True,
+        use_latest_git_ref=True,
+        volume_size_gib={volume_gib},
+        {hardware}
+        cache=False,
+    )
+"""
+        )
+    return "".join(blocks)
+
+
+def _export_block(dataset_id: str) -> str:
+    return f"""
+    from flytekitplugins.domino.artifact import run_launch_export_artifacts_task, ExportArtifactToDatasetsSpec
+    run_launch_export_artifacts_task(
+        spec_list=[
+            ExportArtifactToDatasetsSpec(artifact=DataArtifact, dataset_id="{dataset_id}"),
+            ExportArtifactToDatasetsSpec(artifact=StudyFilesArtifact, dataset_id="{dataset_id}"),
+        ],
+        use_project_defaults_for_omitted=True,
+    )
+"""
+
+
+def render(profile: str, dataset_id: str, include_export: bool) -> str:
+    file_count, total_bytes = profile_totals(profile)
+    header = textwrap.dedent(
+        f"""\
+        # Generated by flows/gen_scale_export_workflow.py — do not edit.
+        # profile={profile} extra_files={file_count} extra_bytes={total_bytes}
+        from flytekit import workflow
+        from flytekit.types.file import FlyteFile
+        from typing import TypeVar
+        from flytekitplugins.domino.helpers import Input, Output, run_domino_job_task
+        from flytekitplugins.domino.artifact import Artifact, DATA, REPORT
+
+        SAS_ENVIRONMENT = "{SAS_ENVIRONMENT}"
+        DataArtifact = Artifact("ADaM Datasets", DATA)
+        ReportArtifact = Artifact("TFL Reports", REPORT)
+        StudyFilesArtifact = Artifact("Study Files", DATA)
+
+        @workflow
+        def {WORKFLOW_NAME}(sdtm_dataset_snapshot: str):
+        """
+    )
+    body = (
+        _sdtm_tasks()
+        + _adam_tasks()
+        + _tfl_tasks()
+        + _emit_tasks(profile)
+        + (_export_block(dataset_id) if include_export else "\n    return\n")
+    )
+    if include_export:
+        body += "\n    return\n"
+    return header + body
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", required=True, choices=("reduced", "full"))
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--out", default=OUTPUT_NAME)
+    parser.add_argument("--skip-export", action="store_true")
+    args = parser.parse_args()
+    out_path = pathlib.Path(args.out)
+    out_path.write_text(render(args.profile, args.dataset_id, include_export=not args.skip_export))
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flows/scale_profiles.py
+++ b/flows/scale_profiles.py
@@ -1,0 +1,161 @@
+"""Scale profiles for DOM-79203 Flows Artifact Export.
+
+Source of truth: the file-size report attached to DOM-79203
+(`file_sizes_top10_stress testing.txt`). Folder file counts and aggregate
+sizes are taken from that report and rounded up for the `full` profile.
+
+The `reduced` profile keeps the same folder mix (many tiny files, a few
+multi-GB files) at roughly 500 files / 20 GB with one 11 GB file, which is
+the shape the CI-runnable scenario uses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+GIB = 1024**3
+MIB = 1024**2
+
+# (folder, file_count, size_gib, default_extension) from the DOM-79203 report
+FOLDER_SPEC = (
+    ("derived_data", 65, 28.82, "sas7bdat"),
+    ("analysis_data", 62, 43.94, "sas7bdat"),
+    ("crt", 495, 111.88, "sas7bdat"),
+    ("pgm", 2126, 0.05, "sas"),
+    ("util", 618, 2.17, "sas7bdat"),
+    ("reports", 1816, 30.95, "rtf"),
+)
+
+# Largest single file in the report, rounded up.
+LARGE_FILE_NAME = "supplb.sas7bdat"
+LARGE_FILE_FOLDER = "crt"
+LARGE_FILE_GIB = 11.0
+
+SDTM_DOMAINS = (
+    "ae",
+    "cm",
+    "dm",
+    "ds",
+    "ex",
+    "lb",
+    "mh",
+    "qs",
+    "relrec",
+    "sc",
+    "se",
+    "suppae",
+    "suppdm",
+    "suppds",
+    "supplb",
+    "sv",
+    "ta",
+    "te",
+    "ti",
+    "ts",
+    "tv",
+    "vs",
+)
+
+FILES_PER_TASK = 10
+LARGE_FILE_THRESHOLD_BYTES = GIB  # files at or above this size get their own task
+
+
+@dataclass(frozen=True)
+class ScaleFile:
+    folder: str
+    name: str
+    size_bytes: int
+    output_name: str
+
+    @property
+    def artifact_filename(self) -> str:
+        return f"{self.folder}__{self.name}"
+
+
+def _distribute(count: int, total_bytes: int, large_file_bytes: int = 0) -> list[int]:
+    """Spread `total_bytes` across `count` files as evenly as possible.
+
+    When `large_file_bytes` is set, that amount is reserved for file 0 and the
+    remainder is spread across the rest. Every file is at least 1 byte.
+    """
+    if count < 1:
+        return []
+    if large_file_bytes and count >= 1:
+        remaining = max(count - 1, 0)
+        rest = max(total_bytes - large_file_bytes, remaining)
+        sizes = [large_file_bytes]
+        if remaining:
+            sizes.extend(_distribute(remaining, rest))
+        return sizes
+    base, extra = divmod(max(total_bytes, count), count)
+    return [base + (1 if i < extra else 0) for i in range(count)]
+
+
+def _folder_files(folder: str, count: int, total_bytes: int, ext: str, large: bool) -> list[ScaleFile]:
+    sizes = _distribute(count, total_bytes, large_file_bytes=int(LARGE_FILE_GIB * GIB) if large else 0)
+    files: list[ScaleFile] = []
+    for i, size in enumerate(sizes):
+        if large and i == 0:
+            name = LARGE_FILE_NAME
+        else:
+            name = f"{folder}_{i:04d}.{ext}"
+        output_name = f"{folder}_{i:04d}"
+        files.append(ScaleFile(folder=folder, name=name, size_bytes=size, output_name=output_name))
+    return files
+
+
+def profile_files(profile: str) -> list[ScaleFile]:
+    """Return the extra artifact files for `reduced` or `full`."""
+    if profile == "full":
+        files: list[ScaleFile] = []
+        for folder, count, size_gib, ext in FOLDER_SPEC:
+            total_bytes = int(round(size_gib * GIB))
+            files.extend(_folder_files(folder, count, total_bytes, ext, large=(folder == LARGE_FILE_FOLDER)))
+        return files
+    if profile == "reduced":
+        # ~500 files / ~20 GiB, preserving folder mix and one 11 GiB file.
+        target_files = 500
+        report_files = sum(spec[1] for spec in FOLDER_SPEC)
+        files: list[ScaleFile] = []
+        allocated = 0
+        for index, (folder, count, _size_gib, ext) in enumerate(FOLDER_SPEC):
+            is_last = index == len(FOLDER_SPEC) - 1
+            scaled = max(1, round(count * target_files / report_files))
+            if is_last:
+                scaled = max(1, target_files - allocated)
+            allocated += scaled
+            if folder == LARGE_FILE_FOLDER:
+                rest_bytes = int(9 * GIB)  # 11 GiB large file + 9 GiB remainder ~= 20 GiB
+                files.extend(_folder_files(folder, scaled, rest_bytes + int(LARGE_FILE_GIB * GIB), ext, large=True))
+            else:
+                # Tiny leftovers: pgm stays tiny; others share ~1 GiB collectively aside from crt.
+                tiny = folder == "pgm"
+                folder_bytes = scaled * 256 if tiny else max(scaled * MIB, MIB)
+                files.extend(_folder_files(folder, scaled, folder_bytes, ext, large=False))
+        return files
+    raise ValueError(f"Unknown scale profile {profile!r}; expected 'reduced' or 'full'")
+
+
+def profile_batches(profile: str) -> list[list[ScaleFile]]:
+    """Group files into Flyte tasks. Multi-GB files run alone so volume size can match."""
+    batches: list[list[ScaleFile]] = []
+    current: list[ScaleFile] = []
+    for scale_file in profile_files(profile):
+        if scale_file.size_bytes >= LARGE_FILE_THRESHOLD_BYTES:
+            if current:
+                batches.append(current)
+                current = []
+            batches.append([scale_file])
+            continue
+        current.append(scale_file)
+        if len(current) >= FILES_PER_TASK:
+            batches.append(current)
+            current = []
+    if current:
+        batches.append(current)
+    return batches
+
+
+def profile_totals(profile: str) -> tuple[int, int]:
+    files = profile_files(profile)
+    return len(files), sum(item.size_bytes for item in files)

--- a/generate_and_run_scale_export.sh
+++ b/generate_and_run_scale_export.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+##
+## Launch the DOM-79203 CDISC1-shaped Flows Artifact Export scale workflow.
+##
+## Usage:
+##   bash generate_and_run_scale_export.sh <dataset_url> <project_name> <profile> [--skip-export]
+##
+## profile is `reduced` or `full`.
+## --skip-export generates the clinical + extra-file DAG without a programmatic
+## export so a Cucu scenario can drive per-stage UI exports instead.
+##
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: bash generate_and_run_scale_export.sh <dataset_url> <project_name> <profile> [--skip-export]" >&2
+  exit 1
+fi
+
+DATASET_URL="$1"
+PROJECT_NAME="$2"
+PROFILE="$3"
+SKIP_EXPORT="${4:-}"
+
+DATASET_ID="$(basename "$DATASET_URL")"
+DATASET_DIR="/domino/datasets/local/${PROJECT_NAME}"
+ROOT="${DOMINO_WORKING_DIR:-/mnt/code}"
+
+cd "$ROOT"
+
+python "$ROOT/scripts/seed_sdtm_placeholders.py" "$DATASET_DIR"
+
+GEN_ARGS=(--profile "$PROFILE" --dataset-id "$DATASET_ID" --out "$ROOT/generate_artifacts_scale_run.py")
+if [[ "$SKIP_EXPORT" == "--skip-export" ]]; then
+  GEN_ARGS+=(--skip-export)
+fi
+python "$ROOT/flows/gen_scale_export_workflow.py" "${GEN_ARGS[@]}"
+
+pyflyte run --remote "$ROOT/generate_artifacts_scale_run.py" export_scale_study \
+  --sdtm_dataset_snapshot "$DATASET_DIR"

--- a/prod/adam_scale/ADAE.sas
+++ b/prod/adam_scale/ADAE.sas
@@ -1,0 +1,10 @@
+* Scale ADAE for DOM-79203. Sequences after ADSL/AE/EX; writes a real sas7bdat.
+libname inputs "/workflow/inputs";
+libname outputs "/workflow/outputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+
+data outputs.adae;
+    set inputs.adsl;
+    length AEDECOD $32;
+    AEDECOD = "HEADACHE";
+run;

--- a/prod/adam_scale/ADCM.sas
+++ b/prod/adam_scale/ADCM.sas
@@ -1,0 +1,10 @@
+* Scale ADCM for DOM-79203.
+libname inputs "/workflow/inputs";
+libname outputs "/workflow/outputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+
+data outputs.adcm;
+    set inputs.adsl;
+    length CMDECOD $32;
+    CMDECOD = "ASPIRIN";
+run;

--- a/prod/adam_scale/ADLB.sas
+++ b/prod/adam_scale/ADLB.sas
@@ -1,0 +1,11 @@
+* Scale ADLB for DOM-79203.
+libname inputs "/workflow/inputs";
+libname outputs "/workflow/outputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+
+data outputs.adlb;
+    set inputs.adsl;
+    length PARAM $32;
+    PARAM = "Hemoglobin";
+    AVAL = 13.5;
+run;

--- a/prod/adam_scale/ADMH.sas
+++ b/prod/adam_scale/ADMH.sas
@@ -1,0 +1,10 @@
+* Scale ADMH for DOM-79203.
+libname inputs "/workflow/inputs";
+libname outputs "/workflow/outputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+
+data outputs.admh;
+    set inputs.adsl;
+    length MHTERM $32;
+    MHTERM = "HYPERTENSION";
+run;

--- a/prod/adam_scale/ADSL.sas
+++ b/prod/adam_scale/ADSL.sas
@@ -1,0 +1,11 @@
+* Scale ADSL for DOM-79203. Generates a small valid SAS dataset so downstream
+* ADaM/TFL tasks have real sas7bdat inputs without depending on CDISC01_SDTM.
+libname outputs "/workflow/outputs";
+
+data outputs.adsl;
+    length USUBJID $8 ACTARM $32 AGE 8 SEX $1;
+    USUBJID = "001"; ACTARM = "Placebo";               AGE = 62; SEX = "F"; output;
+    USUBJID = "002"; ACTARM = "Xanomeline Low Dose";   AGE = 71; SEX = "M"; output;
+    USUBJID = "003"; ACTARM = "Xanomeline High Dose";  AGE = 58; SEX = "F"; output;
+    USUBJID = "004"; ACTARM = "Placebo";               AGE = 66; SEX = "M"; output;
+run;

--- a/prod/adam_scale/ADVS.sas
+++ b/prod/adam_scale/ADVS.sas
@@ -1,0 +1,11 @@
+* Scale ADVS for DOM-79203.
+libname inputs "/workflow/inputs";
+libname outputs "/workflow/outputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+
+data outputs.advs;
+    set inputs.adsl;
+    length PARAM $32;
+    PARAM = "Systolic Blood Pressure";
+    AVAL = 120;
+run;

--- a/prod/tfl_scale/t_ae_rel.sas
+++ b/prod/tfl_scale/t_ae_rel.sas
@@ -1,0 +1,10 @@
+* Scale T_AE_REL for DOM-79203.
+libname inputs "/workflow/inputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+x "mv /workflow/inputs/adae /workflow/inputs/adae.sas7bdat";
+
+ods pdf file="/workflow/outputs/t_ae_rel";
+title "Scale T_AE_REL";
+proc print data=inputs.adae;
+run;
+ods pdf close;

--- a/prod/tfl_scale/t_pop.sas
+++ b/prod/tfl_scale/t_pop.sas
@@ -1,0 +1,9 @@
+* Scale T_POP for DOM-79203. Real SAS PDF from ADSL; no TFL metadata volume required.
+libname inputs "/workflow/inputs";
+x "mv /workflow/inputs/adsl /workflow/inputs/adsl.sas7bdat";
+
+ods pdf file="/workflow/outputs/t_pop";
+title "Scale T_POP";
+proc print data=inputs.adsl;
+run;
+ods pdf close;

--- a/prod/tfl_scale/t_vscat.sas
+++ b/prod/tfl_scale/t_vscat.sas
@@ -1,0 +1,9 @@
+* Scale T_VSCAT for DOM-79203.
+libname inputs "/workflow/inputs";
+x "mv /workflow/inputs/advs /workflow/inputs/advs.sas7bdat";
+
+ods pdf file="/workflow/outputs/t_vscat";
+title "Scale T_VSCAT";
+proc print data=inputs.advs;
+run;
+ods pdf close;

--- a/scripts/emit_scale_artifacts.py
+++ b/scripts/emit_scale_artifacts.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Write one scale-profile batch of artifact files to /workflow/outputs.
+
+Called from generated DominoJobTasks. Files are written in chunks so a
+multi-GB file does not have to fit in RAM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# /mnt/code is the project repo mount inside a Domino job.
+sys.path.insert(0, os.environ.get("DOMINO_WORKING_DIR", "/mnt/code"))
+
+from flows.scale_profiles import profile_batches  # noqa: E402
+
+CHUNK_SIZE = 8 * 1024 * 1024
+OUTPUT_DIR = "/workflow/outputs"
+
+
+def write_file(path: str, size_bytes: int) -> None:
+    remaining = size_bytes
+    with open(path, "wb") as handle:
+        while remaining > 0:
+            chunk = min(CHUNK_SIZE, remaining)
+            handle.write(b"\0" * chunk)
+            remaining -= chunk
+
+
+def main(profile: str, batch_index: int) -> None:
+    batches = profile_batches(profile)
+    if batch_index < 0 or batch_index >= len(batches):
+        raise SystemExit(f"batch {batch_index} out of range 0..{len(batches) - 1}")
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    for scale_file in batches[batch_index]:
+        dest = os.path.join(OUTPUT_DIR, scale_file.output_name)
+        write_file(dest, scale_file.size_bytes)
+        print(f"Wrote {dest} ({scale_file.size_bytes} bytes) as {scale_file.artifact_filename}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", required=True, choices=("reduced", "full"))
+    parser.add_argument("--batch", required=True, type=int)
+    args = parser.parse_args()
+    main(args.profile, args.batch)

--- a/scripts/seed_sdtm_placeholders.py
+++ b/scripts/seed_sdtm_placeholders.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Write placeholder SDTM domain files into a project dataset.
+
+The CDISC1 SDTM-transfer tasks copy `{domain}.sas7bdat` from the dataset
+mount. ADaM scale programs generate their own SAS datasets from datalines, so
+these placeholders only need to exist for the transfer tasks to succeed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.environ.get("DOMINO_WORKING_DIR", "/mnt/code"))
+
+from flows.scale_profiles import SDTM_DOMAINS  # noqa: E402
+
+PLACEHOLDER = b"SDTM_PLACEHOLDER\n"
+
+
+def main(dataset_dir: str) -> None:
+    os.makedirs(dataset_dir, exist_ok=True)
+    for domain in SDTM_DOMAINS:
+        path = os.path.join(dataset_dir, f"{domain}.sas7bdat")
+        with open(path, "wb") as handle:
+            handle.write(PLACEHOLDER)
+        print(f"Wrote {path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.stderr.write("Usage: python scripts/seed_sdtm_placeholders.py <dataset_dir>\n")
+        sys.exit(1)
+    main(sys.argv[1])


### PR DESCRIPTION
## PR Type
- [x] Other... Please describe: Scale-test harness used by the Cucu release-scale test in `internal-e2e-tests-service`.

## What is the current behavior?
CDISC01_Study has the clinical SDTM → ADaM → TFL fan-out (`flows/dev/flow_5_all_SDTM.py`) but no scale profile, no e2e-runnable SAS environment pin, and no programmatic Flows Artifact Export.

Issue Number: https://dominodatalab.atlassian.net/browse/DOM-79203

## What is the new behavior?
Adds a generated scale workflow that:

- Keeps the CDISC1 SDTM → ADaM → TFL topology (dataset snapshots, no NetApp volume IDs).
- Pins SAS tasks to the e2e `SAS Environment`.
- Seeds placeholder SDTM domain files, then emits extra artifact files matching the Novartis file-count/size mix (`reduced` ≈ 500 files / 20 GiB with one 11 GiB file; `full` ≈ 5,182 files / 218 GiB).
- Programmatically exports the accumulated DATA artifacts (`ADaM Datasets` and `Study Files`) to a Domino Dataset.

Launch with:

```
bash generate_and_run_scale_export.sh <dataset_url> <project_name> reduced
bash generate_and_run_scale_export.sh <dataset_url> <project_name> full
bash generate_and_run_scale_export.sh <dataset_url> <project_name> reduced --skip-export
```

The Cucu feature pins this branch until the harness lands on `CSR`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Draft until the companion Cucu PR is up. Extra file generation is chunked so multi-GB files do not have to fit in RAM. Concurrent dataset snapshots are serialized by `export_artifact.sh`; timings from the Cucu run will show that queue.